### PR TITLE
CI conversion to Android build

### DIFF
--- a/.github/workflows/flutter-drive.yaml
+++ b/.github/workflows/flutter-drive.yaml
@@ -5,41 +5,49 @@ on: [ pull_request ]
 # A workflow run is made up of one or more jobs.
 jobs:
   # id of job, a string that is unique to the "jobs" node above.
-  test:
+  android:
+    # The type of machine to run the job on.
+    runs-on: macOS-latest
     # Creates a build matrix for your jobs. You can define different
     # variations of an environment to run each job in.
     strategy:
       # A set of different configurations of the virtual  
       # environment.
       matrix:
-        device:
-        - "iPhone 11 Pro Max (14.4)"
+        api-level:
+          - "29"
       # When set to true, GitHub cancels all in-progress jobs if any        
       # matrix job fails.
       fail-fast: true
-    # The type of machine to run the job on.
-    runs-on: macOS-latest
     # Contains a sequence of tasks.
     steps:
-    # This step lists all available simulators
-    - name: "List all simulators"
-      run: "xcrun xctrace list devices"
-    # This step specifically finds and starts the Iphone 11 Pro Max Simulator
-    - name: "Start Simulator"
-      run: |
-          IPHONE11=$(xcrun xctrace list devices  2>&1  | grep -m 1 "iPhone 11 Pro Max" | awk -F'[()]' '{print $4}')
-          xcrun simctl boot $IPHONE11
     # The branch or tag ref that triggered the workflow will be 
     # checked out.
     # https://github.com/actions/checkout
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    # Sets up Java
+    # https://github.com/actions/setup-java
+    - name: Java 8 Setup
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '8.x'
     # Sets up a flutter environment.
     # https://github.com/marketplace/actions/flutter-action
-    - uses: subosito/flutter-action@v2
+    - name: Setup Flutter SDK
+      uses: subosito/flutter-action@v2
       with:
-        flutter-version: '2.5.3' 
+        flutter-version: '2.5.3'
         channel: 'stable' # or: 'dev' or 'beta'
+    # Unit Tests
     - name: Run Unit Tests
       run: flutter test
+    # Integration Tests
     - name: "Run Flutter Driver tests"
-      run: "flutter drive --target=test_driver/app.dart"
+#     run: "flutter drive --target=test_driver/app.dart"
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: x86_64
+        profile: Nexus 6
+        script: flutter drive --target=test_driver/app.dart

--- a/.github/workflows/flutter-drive.yaml
+++ b/.github/workflows/flutter-drive.yaml
@@ -35,8 +35,9 @@ jobs:
     - uses: actions/checkout@v2
     # Sets up a flutter environment.
     # https://github.com/marketplace/actions/flutter-action
-    - uses: subosito/flutter-action@v1
+    - uses: subosito/flutter-action@v2
       with:
+        flutter-version: '2.5.3' 
         channel: 'stable' # or: 'dev' or 'beta'
     - name: Run Unit Tests
       run: flutter test

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   cupertino_icons: ^0.1.2
 
 dev_dependencies:
-  device_simulator: ^0.9.6
+
   flutter_driver:
     sdk: flutter
 


### PR DESCRIPTION
fix to the github workflow to allow for the Flutter version that runs the tests on Github to have optional null safety on/off, otherwise the newest version of Flutter would run them and the CI will crash due to template's current use of version '2.5.3'

## Overview

<!-- Denote the type of change being made. Select all that apply. -->
**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI change/fix (doesn't break core functionality that changes how app looks)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes  

<!-- Describe the change that is being made. -->
**Proposed Changes**  
*What is the current behavior?*
Github CI breaks when attempting to run checks

*What is the new behavior?*
Github CI should not break when attempting to run checks

*If this PR introduces a breaking change, what changes might users need to make in their application due to this PR?*  
n/a

## Other
*Comments/Questions from the Author*
change made in Summer II 2023

<!-- Before opening the PR ensure that you can check off all of these boxes. -->
## Self-Review  Checklist 
- [x] I have added unit and/or integration tests to cover my changes, or my changes did not require additional tests
- [x] All new and existing tests passed on my local machine.
- [x] I did not add unnecessary comments to the code
- [x] I did not add unnecessary logging or debugging code (print statements, for example).
- [x] Errors are properly handled for code that is risky.
- [x] Naming of methods, variables, and classes is proper.
- [x] I wrote a description of requested changes.
- [x] I performed a self-review of my own code.